### PR TITLE
videos with domain-level privacy dont include the thumnail

### DIFF
--- a/src/video/Vimeo.php
+++ b/src/video/Vimeo.php
@@ -75,7 +75,7 @@ class Vimeo extends Video
 
     public function getVimeoThumbnailUrl(): string
     {
-        return $this->getOembedData()->thumbnail_url;
+        return $this->getOembedData()->thumbnail_url ?? '';
     }
 
     public function getPrivateId(): string


### PR DESCRIPTION
https://developer.vimeo.com/api/oembed/videos#embedding-videos-with-domain-privacy#embedding-videos-with-domain-privacy